### PR TITLE
#bug fix input empty

### DIFF
--- a/src/QuickJumpCore.ts
+++ b/src/QuickJumpCore.ts
@@ -73,6 +73,7 @@ export default abstract class QuickJumpCore<T extends DbCoreItem = DbCoreItem> {
   }
   private async getFolderFromAlias() {
     const folderAlias = await this.getAliasFolder();
+    if (!folderAlias) return;
     const items = folderAlias ? this.getFolderFromDb(folderAlias) : [];
     if (items.length <= 1) {
       return {


### PR DESCRIPTION
在选择之后需要判空(空输入或者esc键), 不然会跳掉 showChoseFolder 函数

![111](https://github.com/webxmsj/vscode-autojump/assets/45585937/362ec117-2bf0-411c-87b4-3cba60ea1b58)

-------------

赞一下作者, 做了我一直想要的功能👏
